### PR TITLE
Fix everybody being able to access certain maintainer console pages

### DIFF
--- a/Web/WebServer.js
+++ b/Web/WebServer.js
@@ -744,6 +744,8 @@ module.exports = (bot, auth, configJS, winston, db = global.Database) => {
 		path = path.replace(`/${svrid}`, "");
 		let section = path;
 		if (path === `/dashboard/management/eval`) section = "eval";
+		else if (path.startsWith(`/dashboard/maintainer`)) return configJSON.maintainers.includes(id);
+		else if (path.startsWith(`/dashboard/servers`)) return configJSON.maintainers.includes(id);
 		else if (path.startsWith(`/dashboard/global-options`)) section = "administration";
 		else if (path.startsWith(`/dashboard/management`)) section = "management";
 		else if (path.startsWith(`/dashboard`) && svrid !== "maintainer") section = "sudoMode";


### PR DESCRIPTION
Namely, /dashboard/maintainer/maintainer, /dashboard/maintainer/servers/server-list and /dashboard/maintainer/servers/big-message

Note: Due to my internet being... [stubborn](https://i.imgur.com/Mpprswd.png) while I made these changes I couldn't test them (because cloning still hasn't finished to this day so I had to edit on Github web). But in theory it works. Said every programmer ever.

**Please describe the changes this PR makes and why it should be merged:**

**What does this PR do:**
- [x] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [x] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [x] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
